### PR TITLE
Add the ability to open in iframe marked links from page content

### DIFF
--- a/assets/components/frontendmanager/js/web/frontend.js
+++ b/assets/components/frontendmanager/js/web/frontend.js
@@ -21,7 +21,7 @@ const frontendManager = {
 		document.body.classList.add('fm', `fm-pos-${frontendManagerConfig.position}`);
 		this.getCookie(cookieKey) && document.body.classList.add(cookieKey);
 
-		this.panel.querySelectorAll(':scope a[data-action="iframe"]')
+		document.querySelectorAll('.fm-row a[data-action="iframe"], a[data-frontendmanager][data-action="iframe"]')
 			.forEach((i) => i.addEventListener('click', (e) => {
 				e.preventDefault();
 				this.open(i.getAttribute('href'));


### PR DESCRIPTION
Add the ability to open in iframe links not only from FM Panel, but also marked links from page content.

Now only links from the FM block can be opened in an Iframe. This code allows to mark ALL links on the page with `data-frontendmanager` attribute and open them in Iframe. 

To use, you need to add the `data-frontendmanager` attribute and `data-action='frame'` to the `a` link on page.

This method will simplify content editing - for example, you can edit any article in the article catalog, any product directly and category and so on. Without opening its page separately.