### PR TITLE
Fix admin area content shift to the right in MODX3

### DIFF
--- a/assets/components/frontendmanager/css/mgr/manager.css
+++ b/assets/components/frontendmanager/css/mgr/manager.css
@@ -13,7 +13,9 @@ label[for="modx-resource-template"] + div,
 	display:none !important;
 }
 
-
+#modx-content {
+	left: 0 !important;
+}
 
 #modx-action-buttons {top: 0;}
 #modx-content {width:100% !important;}


### PR DESCRIPTION
In MODX3, due to positioning content with indentation on the left, the admin shifts to the right. In MODX2 the indentation is 0, so this code fixes the problem in MODX3.